### PR TITLE
Delete variable unsed

### DIFF
--- a/libft/ft_lstmap_bonus.c
+++ b/libft/ft_lstmap_bonus.c
@@ -16,11 +16,9 @@ t_list	*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *))
 {
 	t_list	*new_list;
 	t_list	*new_node;
-	t_list	*lst_head;
 
 	if (!f && !del)
 		return (NULL);
-	lst_head = lst;
 	new_list = NULL;
 	while (lst)
 	{


### PR DESCRIPTION
Delete line 19: t_list	*lst_head;
Delete line 23: lst_head = lst;

Unnecessary lines in the code functionality.